### PR TITLE
fix: fixed all formatting for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
----
+
+```doc
 title: AWS Terraform Modules
-description: >
-  Collection of AWS Terraform modules for personal use.
+description: Collection of AWS Terraform modules for personal use.
 kind: infrastructure
 tags:
   - aws 
   - terraform
 github_url: https://github.com/jonzxz/jonnywritesterraform
+```
+
 ---
 
 # AWS Terraform Modules

--- a/autoscaling/README.md
+++ b/autoscaling/README.md
@@ -1,5 +1,5 @@
 
----
+```doc
 title: Autoscaling
 description: >
   Represents a generic module to create an Autoscaling group and other resources.
@@ -10,6 +10,8 @@ tags:
   - autoscaling
 
 github_url: https://github.com/jonzxz/jonnywritesterraform
+```
+
 ---
 
 # Autoscaling

--- a/bucket-static-site/README.md
+++ b/bucket-static-site/README.md
@@ -1,5 +1,5 @@
 
----
+```doc
 title: Bucket (Static Site)
 description: >
   Represents a generic module to create a S3 Bucket for Static website hosting.
@@ -10,6 +10,8 @@ tags:
   - bucket
 
 github_url: https://github.com/jonzxz/jonnywritesterraform
+```
+
 ---
 
 # Bucket (Static Site)

--- a/bucket/README.md
+++ b/bucket/README.md
@@ -1,5 +1,5 @@
 
----
+```doc
 title: Bucket
 description: >
   Represents a generic module to create a S3 Bucket.
@@ -10,6 +10,8 @@ tags:
   - bucket
 
 github_url: https://github.com/jonzxz/jonnywritesterraform
+```
+
 ---
 
 # Bucket

--- a/ec2/README.md
+++ b/ec2/README.md
@@ -1,5 +1,5 @@
 
----
+```doc
 title: EC2
 description: >
   Represents a generic module to create an EC2 instance.
@@ -10,6 +10,8 @@ tags:
   - ec2
 
 github_url: https://github.com/jonzxz/jonnywritesterraform
+```
+
 ---
 
 # EC2

--- a/loadbalancer/README.md
+++ b/loadbalancer/README.md
@@ -1,5 +1,5 @@
 
----
+```doc
 title: Load Balancer
 description: >
   Represents a generic module to create an Application Load Balancer.
@@ -10,6 +10,8 @@ tags:
   - alb
 
 github_url: https://github.com/jonzxz/jonnywritesterraform
+```
+
 ---
 
 # Load Balancer

--- a/role/README.md
+++ b/role/README.md
@@ -1,5 +1,5 @@
 
----
+```doc
 title: Role
 description: >
   Represents a generic module to create a IAM Role.
@@ -10,6 +10,8 @@ tags:
   - role
 
 github_url: https://github.com/jonzxz/jonnywritesterraform
+```
+
 ---
 
 # Role

--- a/security-group/README.md
+++ b/security-group/README.md
@@ -1,5 +1,5 @@
 
----
+```doc
 title: Security Group
 description: >
   Represents a generic module to create a Security Group.
@@ -10,6 +10,8 @@ tags:
   - security-group
 
 github_url: https://github.com/jonzxz/jonnywritesterraform
+```
+
 ---
 
 # Security Group

--- a/vpc/README.md
+++ b/vpc/README.md
@@ -1,5 +1,5 @@
 
----
+```doc
 title: VPC
 description: >
   Represents a generic module to create a standard 3-tiered VPC with public and private subnets.
@@ -10,6 +10,8 @@ tags:
   - vpc
 
 github_url: https://github.com/jonzxz/jonnywritesterraform
+```
+
 ---
 
 # VPC


### PR DESCRIPTION
Fixed all formatting for README.md to use `doc` instead of `---` to fix markdown rendering.